### PR TITLE
Docs/publish examples

### DIFF
--- a/.changeset/calm-badgers-smoke.md
+++ b/.changeset/calm-badgers-smoke.md
@@ -1,0 +1,5 @@
+---
+'@solid-bricks/barcode': patch
+---
+
+docs: add barcode generator example

--- a/.changeset/kind-nails-jump.md
+++ b/.changeset/kind-nails-jump.md
@@ -1,0 +1,5 @@
+---
+'barcode-generator': patch
+---
+
+docs: deploy barcode-generator example to gh-pages: https://fabervitale.github.io/solid-bricks/examples/barcode-generator/

--- a/.github/workflows/deploy-examples.yaml
+++ b/.github/workflows/deploy-examples.yaml
@@ -7,6 +7,8 @@ permissions:
   contents: write
 jobs:
   build-and-deploy:
+    # prevents this action from running on forks
+    if: github.repository == 'FaberVitale/solid-bricks'
     concurrency: ci-${{ github.ref }} # Recommended if you intend to make multiple deployments in quick succession.
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy-examples.yaml
+++ b/.github/workflows/deploy-examples.yaml
@@ -1,0 +1,33 @@
+name: Deploy examples
+on:
+  push:
+    branches:
+      - docs/publish-examples
+permissions: 
+  contents: write
+jobs:
+  build-and-deploy:
+    concurrency: ci-${{ github.ref }} # Recommended if you intend to make multiple deployments in quick succession.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 'v16.15.0'
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm run build:packages
+
+      - name: Deploy barcode-generator 🚀
+        uses: JamesIves/github-pages-deploy-action@v4.3.3
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: examples/barcode-generator/dist # The folder the action should deploy.
+          target-folder: examples/barcode-generator

--- a/.github/workflows/deploy-examples.yaml
+++ b/.github/workflows/deploy-examples.yaml
@@ -25,6 +25,9 @@ jobs:
       - name: Build packages
         run: pnpm run build:packages
 
+      - name: Build examples
+        run: pnpm run build:examples
+
       - name: Deploy barcode-generator 🚀
         uses: JamesIves/github-pages-deploy-action@v4.3.3
         with:

--- a/.github/workflows/deploy-examples.yaml
+++ b/.github/workflows/deploy-examples.yaml
@@ -2,7 +2,7 @@ name: Deploy examples
 on:
   push:
     branches:
-      - docs/publish-examples
+      - main
 permissions: 
   contents: write
 jobs:

--- a/.github/workflows/deploy-examples.yaml
+++ b/.github/workflows/deploy-examples.yaml
@@ -28,7 +28,7 @@ jobs:
         run: pnpm run build:packages
 
       - name: Build examples
-        run: pnpm run build:examples
+        run: pnpm run build:examples:gh-pages
 
       - name: Deploy barcode-generator 🚀
         uses: JamesIves/github-pages-deploy-action@v4.3.3

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 .DS_Store
 lib
 dist
+*.local
 umd
 build
 coverage

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,3 +1,3 @@
 {
-  "*.{js,jsx,ts,tsx,json,css,scss,sass,md,yml,yaml,cjs,mjs,cts,mts}": "prettier --write"
+  "*.{js,jsx,ts,tsx,json,css,scss,sass,md,yml,yaml,cjs,mjs,cts,mts,html,htm,babelrc}": "prettier --write"
 }

--- a/examples/barcode-generator/index.html
+++ b/examples/barcode-generator/index.html
@@ -4,12 +4,17 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <link rel="icon" href="https://raw.githubusercontent.com/FaberVitale/solid-bricks/main/repo-media/solid-bricks-logo.svg" type=”image/svg+xml”>
+    <link rel="icon"
+    href="https://raw.githubusercontent.com/FaberVitale/solid-bricks/main/repo-media/solid-bricks-logo.svg"
+    type=”image/svg+xml”>
     <meta property="og:title" content="@solid-brick/barcode demo" />
     <meta property="og:type" content="website" />
     <meta property="og:image:width" content="240" />
     <meta property="og:image:height" content="240" />
-    <meta property="og:image" content="https://raw.githubusercontent.com/FaberVitale/solid-bricks/main/repo-media/solid-bricks-logo.svg" />
+    <meta
+      property="og:image"
+      content="https://raw.githubusercontent.com/FaberVitale/solid-bricks/main/repo-media/solid-bricks-logo.svg"
+    />
     <meta
       property="og:description"
       content="A site that showcases @solid-brick/barcode features."

--- a/examples/barcode-generator/index.html
+++ b/examples/barcode-generator/index.html
@@ -4,8 +4,12 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
+    <link rel="icon" href="https://raw.githubusercontent.com/FaberVitale/solid-bricks/main/repo-media/solid-bricks-logo.svg" type=”image/svg+xml”>
     <meta property="og:title" content="@solid-brick/barcode demo" />
     <meta property="og:type" content="website" />
+    <meta property="og:image:width" content="240" />
+    <meta property="og:image:height" content="240" />
+    <meta property="og:image" content="https://raw.githubusercontent.com/FaberVitale/solid-bricks/main/repo-media/solid-bricks-logo.svg" />
     <meta
       property="og:description"
       content="A site that showcases @solid-brick/barcode features."

--- a/examples/barcode-generator/package.json
+++ b/examples/barcode-generator/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "serve": "vite preview",
-    "build:gh-pages": "vite build --base=\"/examples/barcode-generator/\""
+    "build:gh-pages": "vite build --base=\"/solid-bricks/examples/barcode-generator/\""
   },
   "keywords": [
     "barcode",

--- a/examples/barcode-generator/package.json
+++ b/examples/barcode-generator/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "serve": "vite preview"
+    "serve": "vite preview",
+    "build:gh-pages": "vite build --base=\"/examples/barcode-generator/\""
   },
   "keywords": [
     "barcode",

--- a/examples/barcode-generator/src/components/CodeSnippet/styles.module.scss
+++ b/examples/barcode-generator/src/components/CodeSnippet/styles.module.scss
@@ -1,11 +1,11 @@
-@import '../../styles/theme.scss';
+@use '../../styles/_theme.scss';
 
 .floatingBtn {
   position: absolute;
   z-index: 3;
   top: 12px;
   right: 12px;
-  background: $background;
+  background: theme.$background;
 }
 
 .pre {

--- a/examples/barcode-generator/src/hooks/serialize.ts
+++ b/examples/barcode-generator/src/hooks/serialize.ts
@@ -1,0 +1,7 @@
+export function b64EncodeJSON(val: unknown): string {
+  return btoa(encodeURIComponent(JSON.stringify(val)));
+}
+
+export function b64DecodeJSON<T>(val: string): T {
+  return JSON.parse(decodeURIComponent(atob(val)));
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "release": "pnpm run build:packages && changeset publish",
     "build:packages": "pnpm --filter ./packages/* --if-present run build",
     "build:examples": "pnpm --filter ./examples/* --if-present run build",
+    "build:examples:gh-pages": "pnpm --filter ./examples/* --if-present run build:gh-pages",
     "prepare": "husky install",
     "pre-commit:monorepo": "lint-staged",
     "pre-commit:all": "pnpm run pre-commit:monorepo"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint:ts:all": "pnpm -r --if-present run lint:ts",
     "release": "pnpm run build:packages && changeset publish",
     "build:packages": "pnpm --filter ./packages/* --if-present run build",
+    "build:examples": "pnpm --filter ./examples/* --if-present run build",
     "prepare": "husky install",
     "pre-commit:monorepo": "lint-staged",
     "pre-commit:all": "pnpm run pre-commit:monorepo"

--- a/packages/barcode/Readme.md
+++ b/packages/barcode/Readme.md
@@ -26,6 +26,10 @@ yarn add @solid-bricks/barcode
 pnpm add @solid-bricks/barcode
 ```
 
+## Examples
+
+- barcode-generator: **[site](https://fabervitale.github.io/solid-bricks/examples/barcode-generator) - [source](https://github.com/FaberVitale/solid-bricks/tree/main/examples/barcode-generator)**
+
 ## Usage
 
 ```ts


### PR DESCRIPTION
Adds:

- worfklow that automates deployment of examples on gh-pages.
- `build:examples` script
- `build:examples:gh-pages` script
- examples section  to `packages/barcode/Readme.md`

Deploys:

- barcode-generator examples at https://fabervitale.github.io/solid-bricks/examples/barcode-generator
